### PR TITLE
Bounding the noise dependent weights

### DIFF
--- a/fusion/include/fusion/definitions.h
+++ b/fusion/include/fusion/definitions.h
@@ -201,7 +201,7 @@ typedef struct int3_ { int x; int y; int z;} int3;
 
 #define MAXCAMDISTANCE 4.0
 //#define MIN_WEIGHT_FOR_SURFACE 0.0  // This is default
-#define MIN_WEIGHT_FOR_SURFACE 0.1
+#define MIN_WEIGHT_FOR_SURFACE 0.5
 #define ADD_WEIGHTS_TRANSITION_140424
 //#define MAXCAMDISTANCE 6.0
 //#define MIN_WEIGHT_FOR_SURFACE 0.0
@@ -212,7 +212,7 @@ typedef struct int3_ { int x; int y; int z;} int3;
 // karrerm: 15.1.2016
 //#define USE_NOISE_FOR_SCALE 	// Using the depth noise for brick scale
 #define REFERENCE_NOISE 0.025f	// Reference Value for the brick scale using the noise values
-#define MIN_NOISE_LEVEL 0.005f	// Minimal expected noise (used to scale noise dependent weighting)
+#define MIN_NOISE_LEVEL 0.008f	// Minimal expected noise (used to scale noise dependent weighting)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #define REFERENCE_DEPTH 1.0f
 //#define SCALE_VARIANCE
@@ -262,7 +262,7 @@ typedef struct int3_ { int x; int y; int z;} int3;
 //#define DISTANCEMINEXPWEIGHT  0.000001f // this is default
 #define DISTANCEMINEXPWEIGHT  0.005f
 
-#define WEIGHT_FACTOR 1.0f
+#define WEIGHT_FACTOR 2.0f
 
 //float cutoff = expf(-distanceWeightSigma*(threshold-distanceWeightEpsilon)*(threshold-distanceWeightEpsilon));
 //return (float)(distance<distanceWeightEpsilon) +


### PR DESCRIPTION
-Include a upper boundary of the noise dependent weighting scheme by
introduce a lower bound on the noise (all values lower than
MIN_NOISE_LEVEL, are set to be equal to MIN_NOISE_LEVEL). Hence the
heighest weight obtained is one.
